### PR TITLE
No topic on dataEx when topicFilter is not a pattern

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -1357,16 +1357,23 @@ public final class MqttServerFactory implements StreamFactory
             long traceId,
             long authorization,
             int subscriptionId,
+            String topic,
             OctetsFW extension,
             OctetsFW payload)
         {
             final MqttDataExFW dataEx = extension.get(mqttDataExRO::tryWrap);
-            final String16FW topic = dataEx.topic();
-            final String topicName = topic.asString();
-            final int topicNameLength = topicName != null ? topicName.length() : 0;
             final int payloadSize = payload.sizeof();
             final String responseTopic = dataEx.responseTopic().asString();
             final OctetsFW correlation = dataEx.correlation().bytes();
+
+            String topicName = dataEx.topic().asString();
+
+            if (topicName == null)
+            {
+                topicName = topic;
+            }
+
+            final int topicNameLength = topicName != null ? topicName.length() : 0;
 
             if (subscriptionId > 0)
             {
@@ -2086,7 +2093,7 @@ public final class MqttServerFactory implements StreamFactory
                     doNetworkAbort(traceId, authorization);
                 }
 
-                doEncodePublish(traceId, authorization, subscription.id, extension, data.payload());
+                doEncodePublish(traceId, authorization, subscription.id, topicFilter, extension, data.payload());
             }
 
             private void onApplicationEnd(


### PR DESCRIPTION
added capability for topic to not have to be specified on dataEx and grab the topic from the BEGIN for PUBLISH (in the case that the topicfilter is not a pattern and is a specific topic name)