### PR TITLE
Send DISCONNECT to client on rejected PUBLISH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.49</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.30</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.49</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.31</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
@@ -42,19 +42,19 @@ public final class MqttReasonCodes
     public static final byte BAD_USER_NAME_OR_PASSWORD = -0x7A;
     public static final byte NOT_AUTHORIZED = -0x79;
     public static final byte SERVER_UNAVAILABLE = -0x78;
-    public static final byte SERVER_BUSY = -0x76;
-    public static final byte BANNED = -0x75;
-    public static final byte SERVER_SHUTTING_DOWN = -0x74;
-    public static final byte BAD_AUTHENTICATION_METHOD = -0x73;
+    public static final byte SERVER_BUSY = -0x77;
+    public static final byte BANNED = -0x76;
+    public static final byte SERVER_SHUTTING_DOWN = -0x75;
+    public static final byte BAD_AUTHENTICATION_METHOD = -0x74;
 
-    public static final byte KEEP_ALIVE_TIMEOUT = -0x72;
-    public static final byte SESSION_TAKEN_OVER = -0x71;
+    public static final byte KEEP_ALIVE_TIMEOUT = -0x73;
+    public static final byte SESSION_TAKEN_OVER = -0x72;
 
-    public static final byte TOPIC_FILTER_INVALID = -0x70;
-    public static final byte TOPIC_NAME_INVALID = -0x6F;
+    public static final byte TOPIC_FILTER_INVALID = -0x71;
+    public static final byte TOPIC_NAME_INVALID = -0x70;
 
-    public static final byte PACKET_IDENTIFIER_IN_USE = -0x6E;
-    public static final byte PACKET_IDENTIFIER_NOT_FOUND = -0x6D;
+    public static final byte PACKET_IDENTIFIER_IN_USE = -0x6F;
+    public static final byte PACKET_IDENTIFIER_NOT_FOUND = -0x6E;
 
     private MqttReasonCodes()
     {

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -2228,10 +2228,17 @@ public final class MqttServerFactory implements StreamFactory
                 final long traceId = reset.traceId();
                 final long authorization = reset.authorization();
 
-                if (!MqttState.initialOpened(state) &&
-                    hasSubscribeCapability(capabilities))
+                if (!MqttState.initialOpened(state))
                 {
-                    subscription.onSubscribeFailed(traceId, authorization, packetId, subackIndex);
+                    if (hasSubscribeCapability(capabilities))
+                    {
+                        subscription.onSubscribeFailed(traceId, authorization, packetId, subackIndex);
+                    }
+                    else if (hasPublishCapability(capabilities))
+                    {
+                        onDecodeError(traceId, authorization, TOPIC_FILTER_INVALID);
+                        decoder = decodeIgnoreAll;
+                    }
                 }
 
                 decodeNetworkIfNecessary(traceId);

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -27,6 +27,7 @@ import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.NO_SUBSCRIPTI
 import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.PROTOCOL_ERROR;
 import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.SUCCESS;
 import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.TOPIC_FILTER_INVALID;
+import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.TOPIC_NAME_INVALID;
 import static org.reaktivity.nukleus.mqtt.internal.MqttReasonCodes.UNSUPPORTED_PROTOCOL_VERSION;
 import static org.reaktivity.nukleus.mqtt.internal.types.MqttCapabilities.PUBLISH_AND_SUBSCRIBE;
 import static org.reaktivity.nukleus.mqtt.internal.types.MqttCapabilities.PUBLISH_ONLY;
@@ -1150,7 +1151,7 @@ public final class MqttServerFactory implements StreamFactory
             }
             else
             {
-                onDecodeError(traceId, authorization, TOPIC_FILTER_INVALID);
+                onDecodeError(traceId, authorization, TOPIC_NAME_INVALID);
                 decoder = decodeIgnoreAll;
             }
 
@@ -2236,7 +2237,7 @@ public final class MqttServerFactory implements StreamFactory
                     }
                     else if (hasPublishCapability(capabilities))
                     {
-                        onDecodeError(traceId, authorization, TOPIC_FILTER_INVALID);
+                        onDecodeError(traceId, authorization, TOPIC_NAME_INVALID);
                         decoder = decodeIgnoreAll;
                     }
                 }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -2235,7 +2235,8 @@ public final class MqttServerFactory implements StreamFactory
                     {
                         subscription.onSubscribeFailed(traceId, authorization, packetId, subackIndex);
                     }
-                    else if (hasPublishCapability(capabilities))
+
+                    if (hasPublishCapability(capabilities))
                     {
                         onDecodeError(traceId, authorization, TOPIC_NAME_INVALID);
                         decoder = decodeIgnoreAll;

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -336,4 +336,24 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${routeExt}/publish.only/server/controller",
+        "${client}/topic.not.routed/client",
+        "${client}/topic.not.routed/server"})
+    public void shouldRejectPublishWithTopicNotRouted() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${routeExt}/publish.only/controller",
+        "${client}/publish.rejected/client",
+        "${client}/publish.rejected/server"})
+    public void shouldRejectPublish() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -340,8 +340,7 @@ public class ConnectionIT
     @Test
     @Specification({
         "${routeExt}/publish.only/server/controller",
-        "${client}/topic.not.routed/client",
-        "${client}/topic.not.routed/server"})
+        "${client}/topic.not.routed/client"})
     public void shouldRejectPublishWithTopicNotRouted() throws Exception
     {
         k3po.finish();
@@ -349,9 +348,9 @@ public class ConnectionIT
 
     @Test
     @Specification({
-        "${routeExt}/publish.only/controller",
+        "${routeExt}/publish.only/server/controller",
         "${client}/publish.rejected/client",
-        "${client}/publish.rejected/server"})
+        "${server}/publish.rejected/server"})
     public void shouldRejectPublish() throws Exception
     {
         k3po.finish();


### PR DESCRIPTION
Sends DISCONNECT back to client on failed PUBLISH. When routing is failed due to invalid topic up front or later on in the pipeline, sends DISCONNECT with reason code Topic Name Invalid.