### PR TITLE
Verify network END, ABORT, and RESET

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.49</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.32</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.49</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.31</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -361,7 +361,7 @@ public class ConnectionIT
         "${route}/server/controller",
         "${client}/client.sent.close/client",
         "${server}/client.sent.abort/server"})
-    public void shouldDoClientSentClose() throws Exception
+    public void shouldReceiveClientSentClose() throws Exception
     {
         k3po.finish();
     }
@@ -371,7 +371,7 @@ public class ConnectionIT
         "${route}/server/controller",
         "${client}/client.sent.abort/client",
         "${server}/client.sent.abort/server"})
-    public void shouldDoClientSentAbort() throws Exception
+    public void shouldReceiveClientSentAbort() throws Exception
     {
         k3po.finish();
     }
@@ -381,7 +381,7 @@ public class ConnectionIT
         "${route}/server/controller",
         "${client}/client.sent.reset/client",
         "${server}/client.sent.abort/server"})
-    public void shouldDoClientSentReset() throws Exception
+    public void shouldReceiveClientSentReset() throws Exception
     {
         k3po.finish();
     }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -355,4 +355,34 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/close.reply/client",
+        "${server}/abort.application/server"})
+    public void shouldCloseReply() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/abort.reply/client",
+        "${server}/abort.application/server"})
+    public void shouldAbortReply() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/reset.reply/client",
+        "${server}/abort.application/server"})
+    public void shouldResetReply() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -359,9 +359,9 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/close.reply/client",
-        "${server}/abort.application/server"})
-    public void shouldCloseReply() throws Exception
+        "${client}/client.sent.close/client",
+        "${server}/client.sent.abort/server"})
+    public void shouldDoClientSentClose() throws Exception
     {
         k3po.finish();
     }
@@ -369,9 +369,9 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/abort.reply/client",
-        "${server}/abort.application/server"})
-    public void shouldAbortReply() throws Exception
+        "${client}/client.sent.abort/client",
+        "${server}/client.sent.abort/server"})
+    public void shouldDoClientSentAbort() throws Exception
     {
         k3po.finish();
     }
@@ -379,9 +379,9 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
-        "${client}/reset.reply/client",
-        "${server}/abort.application/server"})
-    public void shouldResetReply() throws Exception
+        "${client}/client.sent.reset/client",
+        "${server}/client.sent.abort/server"})
+    public void shouldDoClientSentReset() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Added scripts to verify network reply is closed/aborted/reset via `onNetworkEnd`, `onNetworkAbort`, and `onNetworkReset`. Also tests that application streams are cleaned up and aborts properly in response to network reply.