### PR TITLE
Feature/string types with default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.35</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <k3po.version>3.0.0-alpha-104</k3po.version>
 
-    <nukleus.plugin.version>0.50</nukleus.plugin.version>
+    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
 
     <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <k3po.version>3.0.0-alpha-104</k3po.version>
 
-    <nukleus.plugin.version>develop-SNAPSHOT</nukleus.plugin.version>
+    <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
     <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>


### PR DESCRIPTION
`string8`, `string16`, and `string32` can now specify default values in the .idl (both string literals and null are valid)