### PR TITLE
Update capabilities when PUBLISH comes after SUBSCRIBE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.35</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.36</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -640,13 +640,7 @@ public final class MqttServerFactory implements StreamFactory
                     }
                 }
 
-                assert publisher != null;
-
-                if (!hasPublishCapability(publisher.capabilities))
-                {
-                    publisher.capabilities |= PUBLISH_ONLY.value();
-                    publisher.doApplicationFlush(traceId, authorization, 0);
-                }
+                publisher.updatePublishCapabilityIfNecessary(traceId, authorization);
 
                 final OctetsFW payload = publish.payload();
                 final int payloadSize = payload.sizeof();
@@ -883,18 +877,6 @@ public final class MqttServerFactory implements StreamFactory
             DirectBuffer buffer,
             int offset,
             int limit);
-    }
-
-    private boolean hasPublishCapability(
-        int capabilities)
-    {
-        return (capabilities & PUBLISH_ONLY.value()) != 0;
-    }
-
-    private boolean hasSubscribeCapability(
-        int capabilities)
-    {
-        return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
     }
 
     private final class MqttServer
@@ -2612,6 +2594,29 @@ public final class MqttServerFactory implements StreamFactory
                     signaler.cancel(publishExpiresId);
                     publishExpiresId = NO_CANCEL_ID;
                 }
+            }
+
+            private void updatePublishCapabilityIfNecessary(
+                long traceId,
+                long authorization)
+            {
+                if (!hasPublishCapability(capabilities))
+                {
+                    this.capabilities |= PUBLISH_ONLY.value();
+                    doApplicationFlush(traceId, authorization, 0);
+                }
+            }
+
+            private boolean hasPublishCapability(
+                int capabilities)
+            {
+                return (capabilities & PUBLISH_ONLY.value()) != 0;
+            }
+
+            private boolean hasSubscribeCapability(
+                int capabilities)
+            {
+                return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
             }
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -640,7 +640,7 @@ public final class MqttServerFactory implements StreamFactory
                     }
                 }
 
-                publisher.updatePublishCapabilityIfNecessary(traceId, authorization);
+                publisher.ensurePublishCapability(traceId, authorization);
 
                 final OctetsFW payload = publish.payload();
                 final int payloadSize = payload.sizeof();
@@ -877,6 +877,18 @@ public final class MqttServerFactory implements StreamFactory
             DirectBuffer buffer,
             int offset,
             int limit);
+    }
+
+    private boolean hasPublishCapability(
+        int capabilities)
+    {
+        return (capabilities & PUBLISH_ONLY.value()) != 0;
+    }
+
+    private boolean hasSubscribeCapability(
+        int capabilities)
+    {
+        return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
     }
 
     private final class MqttServer
@@ -2596,7 +2608,7 @@ public final class MqttServerFactory implements StreamFactory
                 }
             }
 
-            private void updatePublishCapabilityIfNecessary(
+            private void ensurePublishCapability(
                 long traceId,
                 long authorization)
             {
@@ -2605,18 +2617,6 @@ public final class MqttServerFactory implements StreamFactory
                     this.capabilities |= PUBLISH_ONLY.value();
                     doApplicationFlush(traceId, authorization, 0);
                 }
-            }
-
-            private boolean hasPublishCapability(
-                int capabilities)
-            {
-                return (capabilities & PUBLISH_ONLY.value()) != 0;
-            }
-
-            private boolean hasSubscribeCapability(
-                int capabilities)
-            {
-                return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
             }
         }
     }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -642,6 +642,12 @@ public final class MqttServerFactory implements StreamFactory
 
                 assert publisher != null;
 
+                if (!hasPublishCapability(publisher.capabilities))
+                {
+                    publisher.capabilities |= PUBLISH_ONLY.value();
+                    publisher.doApplicationFlush(traceId, authorization, 0);
+                }
+
                 final OctetsFW payload = publish.payload();
                 final int payloadSize = payload.sizeof();
 
@@ -877,6 +883,18 @@ public final class MqttServerFactory implements StreamFactory
             DirectBuffer buffer,
             int offset,
             int limit);
+    }
+
+    private boolean hasPublishCapability(
+        int capabilities)
+    {
+        return (capabilities & PUBLISH_ONLY.value()) != 0;
+    }
+
+    private boolean hasSubscribeCapability(
+        int capabilities)
+    {
+        return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
     }
 
     private final class MqttServer
@@ -2046,18 +2064,6 @@ public final class MqttServerFactory implements StreamFactory
                     doEncodeSuback(traceId, authorization, packetId, ackMask, successMask);
                 }
             }
-        }
-
-        private boolean hasPublishCapability(
-            int capabilities)
-        {
-            return (capabilities & PUBLISH_ONLY.value()) != 0;
-        }
-
-        private boolean hasSubscribeCapability(
-            int capabilities)
-        {
-            return (capabilities & SUBSCRIBE_ONLY.value()) != 0;
         }
 
         private class MqttServerStream

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -170,6 +170,16 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
+        "${client}/subscribe.one.message.then.publish.message/client",
+        "${server}/subscribe.one.message.then.publish.message/server"})
+    public void shouldSubscribeOneMessageThenPublishMessage() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
         "${client}/publish.message.and.subscribe.correlated.message/client",
         "${server}/publish.message.and.subscribe.correlated.message/server"})
     public void shouldReceiveCorrelatedPublishAfterSendingSubscribe() throws Exception


### PR DESCRIPTION
Allows streams to update their capabilities from `SUBSCRIBE_ONLY` to `PUBLISH_ONLY` or `PUBLISH_AND_SUBSCRIBE` when client sends `PUBLISH` some time after sending `SUBSCRIBE` for the same topic.