### PR TITLE
Feature/connect timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.37</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.38</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -45,17 +45,17 @@ public class MqttConfiguration extends Configuration
         super(MQTT_CONFIG, config);
     }
 
-    public long getPublishTimeout()
+    public long publishTimeout()
     {
         return PUBLISH_TIMEOUT.get(this);
     }
 
-    public long getConnectTimeout()
+    public long connectTimeout()
     {
         return CONNECT_TIMEOUT.get(this);
     }
 
-    public String getClientId()
+    public String clientId()
     {
         return CLIENT_ID.get(this);
     }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -22,9 +22,11 @@ import org.reaktivity.nukleus.Configuration;
 public class MqttConfiguration extends Configuration
 {
     public static final String PUBLISH_TIMEOUT_NAME = "nukleus.mqtt.publish.timeout";
+    public static final String CONNECT_TIMEOUT_NAME = "nukleus.mqtt.connect.timeout";
     public static final String CLIENT_ID_NAME = "nukleus.mqtt.client.id";
 
     private static final ConfigurationDef MQTT_CONFIG;
+    public static final LongPropertyDef CONNECT_TIMEOUT;
     public static final LongPropertyDef PUBLISH_TIMEOUT;
     public static final PropertyDef<String> CLIENT_ID;
 
@@ -32,6 +34,7 @@ public class MqttConfiguration extends Configuration
     {
         final ConfigurationDef config = new ConfigurationDef("nukleus.mqtt");
         PUBLISH_TIMEOUT = config.property("publish.timeout", TimeUnit.SECONDS.toSeconds(30));
+        CONNECT_TIMEOUT = config.property("connect.timeout", TimeUnit.SECONDS.toSeconds(3));
         CLIENT_ID = config.property("client.id", "client");
         MQTT_CONFIG = config;
     }
@@ -45,6 +48,11 @@ public class MqttConfiguration extends Configuration
     public long getPublishTimeout()
     {
         return PUBLISH_TIMEOUT.get(this);
+    }
+
+    public long getConnectTimeout()
+    {
+        return CONNECT_TIMEOUT.get(this);
     }
 
     public String getClientId()

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
@@ -56,6 +56,8 @@ public final class MqttReasonCodes
     public static final byte PACKET_IDENTIFIER_IN_USE = -0x6F;
     public static final byte PACKET_IDENTIFIER_NOT_FOUND = -0x6E;
 
+    public static final byte MAXIMUM_CONNECT_TIME = -0x60;
+
     private MqttReasonCodes()
     {
         // Utility

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
@@ -56,8 +56,6 @@ public final class MqttReasonCodes
     public static final byte PACKET_IDENTIFIER_IN_USE = -0x6F;
     public static final byte PACKET_IDENTIFIER_NOT_FOUND = -0x6E;
 
-    public static final byte MAXIMUM_CONNECT_TIME = -0x60;
-
     private MqttReasonCodes()
     {
         // Utility

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -261,9 +261,9 @@ public final class MqttServerFactory implements StreamFactory
         this.correlations = new Long2ObjectHashMap<>();
         this.mqttTypeId = supplyTypeId.applyAsInt(MqttNukleus.NAME);
         this.signaler = signaler;
-        this.clientId = config.getClientId();
-        this.publishTimeoutMillis = SECONDS.toMillis(config.getPublishTimeout());
-        this.connectTimeoutMillis = SECONDS.toMillis(config.getConnectTimeout());
+        this.clientId = config.clientId();
+        this.publishTimeoutMillis = SECONDS.toMillis(config.publishTimeout());
+        this.connectTimeoutMillis = SECONDS.toMillis(config.connectTimeout());
         this.encodeBudgetMax = bufferPool.slotCapacity();
         this.validator = new MqttValidator();
     }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -120,6 +120,7 @@ public final class MqttServerFactory implements StreamFactory
 
     private static final int PUBLISH_EXPIRED_SIGNAL = 1;
     private static final int KEEP_ALIVE_TIMEOUT_SIGNAL = 2;
+    private static final int CONNECT_TIMEOUT_SIGNAL = 3;
 
     private static final int PUBLISH_FRAMING = 255;
 
@@ -189,6 +190,7 @@ public final class MqttServerFactory implements StreamFactory
 
     private final String clientId;
     private final long publishTimeoutMillis;
+    private final long connectTimeoutMillis;
     private final int encodeBudgetMax;
 
     private final MqttValidator validator;
@@ -261,6 +263,7 @@ public final class MqttServerFactory implements StreamFactory
         this.signaler = signaler;
         this.clientId = config.getClientId();
         this.publishTimeoutMillis = SECONDS.toMillis(config.getPublishTimeout());
+        this.connectTimeoutMillis = SECONDS.toMillis(config.getConnectTimeout());
         this.encodeBudgetMax = bufferPool.slotCapacity();
         this.validator = new MqttValidator();
     }
@@ -923,6 +926,9 @@ public final class MqttServerFactory implements StreamFactory
         private int decodePublisherKey;
         private int decodeablePacketBytes;
 
+        private long connectTimeoutId = NO_CANCEL_ID;
+        private long connectTimeoutAt;
+
         private long keepAliveTimeoutId = NO_CANCEL_ID;
         private long keepAliveTimeoutAt;
 
@@ -1003,6 +1009,7 @@ public final class MqttServerFactory implements StreamFactory
 
             doNetworkBegin(traceId, authorization);
             doNetworkWindow(traceId, authorization, bufferPool.slotCapacity(), 0, 0L);
+            doSignalConnectTimeoutIfNecessary();
         }
 
         private void onNetworkData(
@@ -1136,6 +1143,9 @@ public final class MqttServerFactory implements StreamFactory
             case KEEP_ALIVE_TIMEOUT_SIGNAL:
                 onKeepAliveTimeoutSignal(signal);
                 break;
+            case CONNECT_TIMEOUT_SIGNAL:
+                onConnectTimeoutSignal(signal);
+                break;
             default:
                 break;
             }
@@ -1159,6 +1169,30 @@ public final class MqttServerFactory implements StreamFactory
             }
         }
 
+        private void onConnectTimeoutSignal(
+            SignalFW signal)
+        {
+            final long traceId = signal.traceId();
+            final long authorization = signal.authorization();
+
+            final long now = System.currentTimeMillis();
+            if (now >= connectTimeoutAt)
+            {
+                cleanupStreams(traceId, authorization);
+                doNetworkEnd(traceId, authorization);
+                decoder = decodeIgnoreAll;
+            }
+        }
+
+        private void doCancelConnectTimeoutIfNecessary()
+        {
+            if (connectTimeoutId != NO_CANCEL_ID)
+            {
+                signaler.cancel(connectTimeoutId);
+                connectTimeoutId = NO_CANCEL_ID;
+            }
+        }
+
         private void onDecodeConnect(
             long traceId,
             long authorization,
@@ -1170,6 +1204,7 @@ public final class MqttServerFactory implements StreamFactory
                 reasonCode = PROTOCOL_ERROR;
             }
 
+            doCancelConnectTimeoutIfNecessary();
             doEncodeConnack(traceId, authorization, reasonCode);
 
             if (reasonCode == 0)
@@ -2013,6 +2048,16 @@ public final class MqttServerFactory implements StreamFactory
                 {
                     keepAliveTimeoutId = signaler.signalAt(keepAliveTimeoutAt, routeId, replyId, KEEP_ALIVE_TIMEOUT_SIGNAL);
                 }
+            }
+        }
+
+        private void doSignalConnectTimeoutIfNecessary()
+        {
+            connectTimeoutAt = System.currentTimeMillis() + connectTimeoutMillis;
+
+            if (connectTimeoutId == NO_CANCEL_ID)
+            {
+                connectTimeoutId = signaler.signalAt(connectTimeoutAt, routeId, replyId, CONNECT_TIMEOUT_SIGNAL);
             }
         }
 

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConfigurationTest.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConfigurationTest.java
@@ -18,6 +18,8 @@ package org.reaktivity.nukleus.mqtt.internal;
 import static org.junit.Assert.assertEquals;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CLIENT_ID;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CLIENT_ID_NAME;
+import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CONNECT_TIMEOUT;
+import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CONNECT_TIMEOUT_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.PUBLISH_TIMEOUT;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.PUBLISH_TIMEOUT_NAME;
 
@@ -30,5 +32,6 @@ public class ConfigurationTest
     {
         assertEquals(CLIENT_ID.name(), CLIENT_ID_NAME);
         assertEquals(PUBLISH_TIMEOUT.name(), PUBLISH_TIMEOUT_NAME);
+        assertEquals(CONNECT_TIMEOUT.name(), CONNECT_TIMEOUT_NAME);
     }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -461,4 +461,13 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/timeout.before.connect/client"})
+    public void shouldTimeoutBeforeConnect() throws Exception
+    {
+        k3po.finish();
+    }
 }


### PR DESCRIPTION
Fixes #53 

Server must end client connection if no `CONNECT` was sent within a configurable time frame from establishing the network connection.

Timeout is set via `MqttConfiguration`.