### PR TITLE
Support server assigned client identifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.40</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.39</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.53</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.41</nukleus.mqtt.spec.version>
     <reaktor.version>0.130</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -74,6 +74,7 @@ import org.reaktivity.nukleus.mqtt.internal.types.MqttBinaryFW;
 import org.reaktivity.nukleus.mqtt.internal.types.MqttCapabilities;
 import org.reaktivity.nukleus.mqtt.internal.types.MqttPayloadFormat;
 import org.reaktivity.nukleus.mqtt.internal.types.OctetsFW;
+import org.reaktivity.nukleus.mqtt.internal.types.String16FW;
 import org.reaktivity.nukleus.mqtt.internal.types.String8FW;
 import org.reaktivity.nukleus.mqtt.internal.types.codec.MqttConnackFW;
 import org.reaktivity.nukleus.mqtt.internal.types.codec.MqttConnectFW;
@@ -1204,11 +1205,12 @@ public final class MqttServerFactory implements StreamFactory
                 reasonCode = PROTOCOL_ERROR;
             }
 
-            final String clientIdentifier = packet.clientId().asString();
+            final String16FW clientIdentifier = packet.clientId();
 
             mqttPropertyRW.wrap(propertyBuffer, 0, propertyBuffer.capacity());
 
-            if (clientIdentifier != null && clientIdentifier.isEmpty())
+            final DirectBuffer value = clientIdentifier.value();
+            if (value != null && value.capacity() == 0)
             {
                 mqttPropertyRW.assignedClientId(clientId);
             }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -1751,7 +1751,7 @@ public final class MqttServerFactory implements StreamFactory
             long traceId,
             long authorization,
             int reasonCode,
-            DirectBuffer clientIdValue)
+            DirectBuffer clientId)
         {
             int propertiesSize = 0;
 
@@ -1764,9 +1764,9 @@ public final class MqttServerFactory implements StreamFactory
                 propertiesSize += mqttProperty.limit();
             }
 
-            if (clientIdValue != null && clientIdValue.capacity() == 0)
+            if (clientId != null && clientId.capacity() == 0)
             {
-                mqttProperty.assignedClientId(clientId);
+                mqttProperty.assignedClientId(MqttServerFactory.this.clientId);
                 propertiesSize += mqttProperty.limit();
             }
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -1253,13 +1253,6 @@ public final class MqttServerFactory implements StreamFactory
 
             final String16FW clientIdentifier = packet.clientId();
 
-            // final DirectBuffer value = clientIdentifier.value();
-            // if (value != null && value.capacity() == 0)
-            // {
-            //     mqttPropertyRW.wrap(propertyBuffer, 0, propertyBuffer.capacity())
-            //                   .assignedClientId(clientId);
-            // }
-
             doCancelConnectTimeoutIfNecessary();
             doEncodeConnack(traceId, authorization, reasonCode, clientIdentifier.value());
 
@@ -1521,7 +1514,7 @@ public final class MqttServerFactory implements StreamFactory
             }
             else
             {
-                doEncodeConnack(traceId, authorization, reasonCode, EMPTY_OCTETS.buffer());
+                doEncodeConnack(traceId, authorization, reasonCode, null);
             }
             doNetworkEnd(traceId, authorization);
         }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -1755,18 +1755,19 @@ public final class MqttServerFactory implements StreamFactory
         {
             int propertiesSize = 0;
 
+            final MqttPropertyFW.Builder mqttProperty = mqttPropertyRW.wrap(propertyBuffer,
+                propertiesSize, propertyBuffer.capacity());
+
             if (topicAliasMaximum > 0)
             {
-                mqttPropertyRW.wrap(propertyBuffer, propertiesSize, propertyBuffer.capacity())
-                              .topicAliasMaximum(topicAliasMaximum);
-                propertiesSize += mqttPropertyRW.limit();
+                mqttProperty.topicAliasMaximum(topicAliasMaximum);
+                propertiesSize += mqttProperty.limit();
             }
 
             if (clientIdValue != null && clientIdValue.capacity() == 0)
             {
-                mqttPropertyRW.wrap(propertyBuffer, propertiesSize, propertyBuffer.capacity())
-                              .assignedClientId(clientId);
-                propertiesSize += mqttPropertyRW.limit();
+                mqttProperty.assignedClientId(clientId);
+                propertiesSize += mqttProperty.limit();
             }
 
             final int propertiesSize0 = propertiesSize;

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -77,6 +77,15 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
+        "${client}/connect/reject.missing.client.id/client"})
+    public void shouldRejectMissingClientId() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
         "${client}/ping/client"})
     public void shouldExchangeConnectionPacketsThenPingPackets() throws Exception
     {

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -68,6 +68,15 @@ public class ConnectionIT
     @Test
     @Specification({
         "${route}/server/controller",
+        "${client}/connect/server.assigned.client.id/client"})
+    public void shouldExchangeConnectAndConnackPacketsWithServerAssignedClientId() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
         "${client}/ping/client"})
     public void shouldExchangeConnectionPacketsThenPingPackets() throws Exception
     {


### PR DESCRIPTION
fix #48 

Upon receiving an zero length client identifier on `CONNECT`, server must assign a unique client identifier to the client via `CONNACK`