### PR TITLE
Relax MQTT CONNECT properties strictness check

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -30,7 +30,7 @@ public class MqttConfiguration extends Configuration
     public static final LongPropertyDef CONNECT_TIMEOUT;
     public static final LongPropertyDef PUBLISH_TIMEOUT;
     public static final PropertyDef<String> CLIENT_ID;
-    public static final BytePropertyDef RETAIN_AVAILABLE;
+    public static final BooleanPropertyDef RETAIN_AVAILABLE;
 
     static
     {
@@ -38,7 +38,7 @@ public class MqttConfiguration extends Configuration
         PUBLISH_TIMEOUT = config.property("publish.timeout", TimeUnit.SECONDS.toSeconds(30));
         CONNECT_TIMEOUT = config.property("connect.timeout", TimeUnit.SECONDS.toSeconds(3));
         CLIENT_ID = config.property("client.id", "client");
-        RETAIN_AVAILABLE = config.property("retain.available", (byte) 0x01);
+        RETAIN_AVAILABLE = config.property("retain.available", true);
         MQTT_CONFIG = config;
     }
 
@@ -63,7 +63,7 @@ public class MqttConfiguration extends Configuration
         return CLIENT_ID.get(this);
     }
 
-    public byte retainAvailable()
+    public boolean retainAvailable()
     {
         return RETAIN_AVAILABLE.get(this);
     }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -24,11 +24,13 @@ public class MqttConfiguration extends Configuration
     public static final String PUBLISH_TIMEOUT_NAME = "nukleus.mqtt.publish.timeout";
     public static final String CONNECT_TIMEOUT_NAME = "nukleus.mqtt.connect.timeout";
     public static final String CLIENT_ID_NAME = "nukleus.mqtt.client.id";
+    public static final String RETAIN_AVAILABLE_NAME = "nukleus.mqtt.retain.available";
 
     private static final ConfigurationDef MQTT_CONFIG;
     public static final LongPropertyDef CONNECT_TIMEOUT;
     public static final LongPropertyDef PUBLISH_TIMEOUT;
     public static final PropertyDef<String> CLIENT_ID;
+    public static final BytePropertyDef RETAIN_AVAILABLE;
 
     static
     {
@@ -36,6 +38,7 @@ public class MqttConfiguration extends Configuration
         PUBLISH_TIMEOUT = config.property("publish.timeout", TimeUnit.SECONDS.toSeconds(30));
         CONNECT_TIMEOUT = config.property("connect.timeout", TimeUnit.SECONDS.toSeconds(3));
         CLIENT_ID = config.property("client.id", "client");
+        RETAIN_AVAILABLE = config.property("retain.available", (byte) 0x01);
         MQTT_CONFIG = config;
     }
 
@@ -58,5 +61,10 @@ public class MqttConfiguration extends Configuration
     public String clientId()
     {
         return CLIENT_ID.get(this);
+    }
+
+    public byte retainAvailable()
+    {
+        return RETAIN_AVAILABLE.get(this);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttReasonCodes.java
@@ -58,6 +58,8 @@ public final class MqttReasonCodes
     public static final byte RECEIVE_MAXIMUM_EXCEEDED = (byte) 0x93;
     public static final byte TOPIC_ALIAS_INVALID = (byte) 0x94;
 
+    public static final byte RETAIN_NOT_SUPPORTED = (byte) 0x9A;
+
     private MqttReasonCodes()
     {
         // Utility

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -586,8 +586,8 @@ public final class MqttServerFactory implements StreamFactory
             {
                 reasonCode = PROTOCOL_ERROR;
             }
-            else if ((mqttConnect.flags() & 0b0000_0001) != 0b0000_0000 ||
-                         (mqttConnect.typeAndFlags() & 0b1111_1111) != CONNECT_FIXED_HEADER)
+            else if ((mqttConnect.typeAndFlags() & 0b1111_1111) != CONNECT_FIXED_HEADER ||
+                     (mqttConnect.flags() & 0b0000_0001) != 0b0000_0000)
             {
                 reasonCode = MALFORMED_PACKET;
             }


### PR DESCRIPTION
Fixes issue where `onDecodeConnect` only accounts for `KIND_TOPIC_ALIAS_MAXIMUM` when checking the properties on the `CONNECT` packet. Now no longer rejects `CONNECT` containing other properties with `0x81 MALFORMED PACKET`.

Also adds a check to make sure that lower 4 bits of `CONNECT` header are all 0, and corrected erroneous `CONNECT_FIXED_HEADER` value.