### PR TITLE
Changed WillPayload to BinaryFW

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.71</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.51</nukleus.mqtt.spec.version>
     <reaktor.version>0.146</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.71</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.50</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.146</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -104,6 +104,7 @@ import org.reaktivity.nukleus.mqtt.internal.types.MqttPayloadFormat;
 import org.reaktivity.nukleus.mqtt.internal.types.MqttPayloadFormatFW;
 import org.reaktivity.nukleus.mqtt.internal.types.OctetsFW;
 import org.reaktivity.nukleus.mqtt.internal.types.String16FW;
+import org.reaktivity.nukleus.mqtt.internal.types.codec.BinaryFW;
 import org.reaktivity.nukleus.mqtt.internal.types.codec.MqttConnackFW;
 import org.reaktivity.nukleus.mqtt.internal.types.codec.MqttConnectFW;
 import org.reaktivity.nukleus.mqtt.internal.types.codec.MqttDisconnectFW;
@@ -246,7 +247,7 @@ public final class MqttServerFactory implements StreamFactory
 
     private final OctetsFW.Builder sessionPayloadRW = new OctetsFW.Builder();
 
-    private final OctetsFW willPayloadRO = new OctetsFW();
+    private final BinaryFW willPayloadRO = new BinaryFW();
     private final OctetsFW passwordRO = new OctetsFW();
 
     private final MqttPublishHeader mqttPublishHeaderRO = new MqttPublishHeader();
@@ -1501,7 +1502,7 @@ public final class MqttServerFactory implements StreamFactory
                         0, PUBLISH_ONLY);
                 }
 
-                final int payloadSize = sessionPayload.sizeof() + payload.willPayload.sizeof();
+                final int payloadSize = sessionPayload.sizeof() + payload.willPayload.bytes().sizeof();
 
                 boolean canPublish = MqttState.initialOpened(sessionStream.state);
 
@@ -1522,7 +1523,7 @@ public final class MqttServerFactory implements StreamFactory
 
                     onEncodeSession(sessionStream, traceId, authorization, reserved, connect.flags(), willFlags,
                         payload.willTopic, payload.expiryInterval, payload.contentType, payload.payloadFormat,
-                        payload.responseTopic, payload.correlationData, sessionPayload, payload.willPayload);
+                        payload.responseTopic, payload.correlationData, sessionPayload, payload.willPayload.bytes());
 
                     if (reasonCode == SUCCESS)
                     {
@@ -4188,7 +4189,7 @@ public final class MqttServerFactory implements StreamFactory
         private byte willQos = 0;
         private byte willRetain = 0;
         private String16FW willTopic = null;
-        private OctetsFW willPayload = null;
+        private BinaryFW willPayload = null;
         private String16FW username = null;
         private OctetsFW password = null;
 


### PR DESCRIPTION
`willPayload` requires a 2-byte length prefix, so to account for the fix `willPayload` was changed to `BinaryFW` to account for the length prefix as well as the payload data itself