### PR TITLE
Feature/no local

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.71</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.52</nukleus.mqtt.spec.version>
     <reaktor.version>0.146</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.71</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.50</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.146</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -2488,7 +2488,6 @@ public final class MqttServerFactory implements StreamFactory
             private int ackCount;
             private int successMask;
             private int ackMask;
-            private boolean acknowledged;
 
             private Subscription()
             {
@@ -2525,9 +2524,14 @@ public final class MqttServerFactory implements StreamFactory
             {
                 if (Integer.bitCount(ackMask) == ackCount)
                 {
-                    acknowledged = true;
                     doEncodeSuback(traceId, authorization, packetId, ackMask, successMask);
                 }
+            }
+
+            private boolean hasSubscribeCompleted(
+                int ackIndex)
+            {
+                return (ackMask & 1 << ackIndex) != 0;
             }
 
             private boolean retainAsPublished()
@@ -2797,7 +2801,8 @@ public final class MqttServerFactory implements StreamFactory
                 final int credit = window.credit();
                 final int padding = window.padding();
 
-                if (subscription != null && !subscription.acknowledged && hasSubscribeCapability(capabilities))
+                if (subscription != null &&
+                        !subscription.hasSubscribeCompleted(subackIndex) && hasSubscribeCapability(capabilities))
                 {
                     subscription.onSubscribeSucceeded(traceId, authorization, packetId, subackIndex);
                 }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -2488,6 +2488,7 @@ public final class MqttServerFactory implements StreamFactory
             private int ackCount;
             private int successMask;
             private int ackMask;
+            private boolean acknowledged;
 
             private Subscription()
             {
@@ -2524,6 +2525,7 @@ public final class MqttServerFactory implements StreamFactory
             {
                 if (Integer.bitCount(ackMask) == ackCount)
                 {
+                    acknowledged = true;
                     doEncodeSuback(traceId, authorization, packetId, ackMask, successMask);
                 }
             }
@@ -2559,7 +2561,6 @@ public final class MqttServerFactory implements StreamFactory
 
             private int state;
             private int capabilities;
-            private boolean didSendSuback;
 
             private long publishExpiresId = NO_CANCEL_ID;
             private long publishExpiresAt;
@@ -2796,9 +2797,8 @@ public final class MqttServerFactory implements StreamFactory
                 final int credit = window.credit();
                 final int padding = window.padding();
 
-                if (!didSendSuback && hasSubscribeCapability(capabilities))
+                if (subscription != null && !subscription.acknowledged && hasSubscribeCapability(capabilities))
                 {
-                    didSendSuback = true;
                     subscription.onSubscribeSucceeded(traceId, authorization, packetId, subackIndex);
                 }
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -1734,7 +1734,7 @@ public final class MqttServerFactory implements StreamFactory
                         final int flags = calculateSubscribeFlags(traceId, authorization, options);
                         subscription.flags = flags;
 
-                        if (!noLocal && (flags & NO_LOCAL_FLAG) != 0)
+                        if (!noLocal && isSetNoLocal(flags))
                         {
                             onDecodeError(traceId, authorization, PROTOCOL_ERROR);
                             decoder = decodeIgnoreAll;
@@ -2727,6 +2727,7 @@ public final class MqttServerFactory implements StreamFactory
                                                            .typeId(mqttTypeId)
                                                            .flags(flags)
                                                            .capabilities(c -> c.set(valueOf(capabilities)))
+                                                           .clientId(clientId)
                                                            .build()
                                                            .sizeof()));
             }
@@ -2795,8 +2796,8 @@ public final class MqttServerFactory implements StreamFactory
                 final int credit = window.credit();
                 final int padding = window.padding();
 
-                if (!MqttState.initialOpened(state) &&
-                    hasSubscribeCapability(capabilities))
+                final boolean b = !MqttState.initialOpened(state);
+                if (b && hasSubscribeCapability(capabilities))
                 {
                     subscription.onSubscribeSucceeded(traceId, authorization, packetId, subackIndex);
                 }
@@ -4129,6 +4130,12 @@ public final class MqttServerFactory implements StreamFactory
         int flags)
     {
         return (flags & PASSWORD_MASK) != 0;
+    }
+
+    private static boolean isSetNoLocal(
+        int flags)
+    {
+        return (flags & NO_LOCAL_FLAG) != 0;
     }
 
     private static boolean isSetBasicAuthentication(

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -20,6 +20,7 @@ import static org.junit.rules.RuleChain.outerRule;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.PUBLISH_TIMEOUT;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.CLIENT_ID_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.MAXIMUM_QOS_NAME;
+import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.NO_LOCAL_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.RETAIN_AVAILABLE_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.SESSION_EXPIRY_INTERVAL_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.SHARED_SUBSCRIPTION_AVAILABLE_NAME;
@@ -1055,12 +1056,56 @@ public class ConnectionIT
         "${routeExt}/session/server/controller",
         "${client}/connect/will.message.with.normal.disconnect/client",
         "${server}/unpublished.will.message/server"})
-    @Configure(name = CLIENT_ID_NAME, value = "one")
     @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
     @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
     @Configure(name = MAXIMUM_QOS_NAME, value = "2")
     @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "0")
+    @Configure(name = CLIENT_ID_NAME, value = "one")
     public void shouldIgnoreWillMessageAfterNormalClientDisconnect() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/publish.then.subscribe.one.message/client",
+        "${server}/publish.then.subscribe.one.message/server"})
+    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
+    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "0")
+    public void shouldPublishThenSubscribeOneMessage() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/subscribe.then.publish.no.local/client",
+        "${server}/subscribe.then.publish.no.local/server"})
+    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
+    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "0")
+    @Configure(name = NO_LOCAL_NAME, value = "true")
+    public void shouldSubscribeThenPublishNoLocal() throws Exception
+    {
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
+        "${route}/server/controller",
+        "${client}/publish.then.subscribe.no.local/client",
+        "${server}/publish.then.subscribe.no.local/server"})
+    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
+    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "0")
+    @Configure(name = NO_LOCAL_NAME, value = "true")
+    public void shouldPublishThenSubscribeNoLocal() throws Exception
     {
         k3po.finish();
     }


### PR DESCRIPTION
Fix #67 
Requires https://github.com/reaktivity/nukleus-mqtt.spec/pull/49

Added  `SUBSCRIBE_ONLY` -> `PUBLISH_AND_SUBSCRIBE` no-local and `PUBLISH_ONLY` -> `PUBLISH_AND_SUBSCRIBE` no-local scenarios. PUBLISH_ONLY` -> `PUBLISH_AND_SUBSCRIBE` also now properly encodes and sends `SUBACK` to the client.