### PR TITLE
Fix sending of Will Message over application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.78</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>0.56</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
     <reaktor.version>0.152</reaktor.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
     <nukleus.plugin.version>0.78</nukleus.plugin.version>
 
-    <nukleus.mqtt.spec.version>develop-SNAPSHOT</nukleus.mqtt.spec.version>
+    <nukleus.mqtt.spec.version>0.57</nukleus.mqtt.spec.version>
     <reaktor.version>0.152</reaktor.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -49,7 +49,7 @@ public class MqttConfiguration extends Configuration
         SHARED_SUBSCRIPTION_AVAILABLE = config.property("shared.subscription.available", false);
         NO_LOCAL = config.property("no.local", true);
         SESSION_EXPIRY_GRACE_PERIOD = config.property("session.expiry.grace.period", 30);
-        CLIENT_ID = config.property("client.id", (String) null);
+        CLIENT_ID = config.property("client.id");
         MQTT_CONFIG = config;
     }
 

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -40,7 +40,7 @@ public class MqttConfiguration extends Configuration
         final ConfigurationDef config = new ConfigurationDef("nukleus.mqtt");
         PUBLISH_TIMEOUT = config.property("publish.timeout", TimeUnit.SECONDS.toSeconds(30));
         CONNECT_TIMEOUT = config.property("connect.timeout", TimeUnit.SECONDS.toSeconds(3));
-        SESSION_EXPIRY_INTERVAL = config.property("session.expiry.interval", 0);
+        SESSION_EXPIRY_INTERVAL = config.property("session.expiry.interval", Integer.MAX_VALUE);
         MAXIMUM_QOS = config.property("maximum.qos", (byte) 0);
         RETAIN_AVAILABLE = config.property("retain.available", true);
         TOPIC_ALIAS_MAXIMUM = config.property("topic.alias.maximum", (short) 0);

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/MqttConfiguration.java
@@ -33,6 +33,7 @@ public class MqttConfiguration extends Configuration
     public static final BooleanPropertyDef SHARED_SUBSCRIPTION_AVAILABLE;
     public static final BooleanPropertyDef NO_LOCAL;
     public static final IntPropertyDef SESSION_EXPIRY_GRACE_PERIOD;
+    public static final PropertyDef<String> CLIENT_ID;
 
     static
     {
@@ -48,6 +49,7 @@ public class MqttConfiguration extends Configuration
         SHARED_SUBSCRIPTION_AVAILABLE = config.property("shared.subscription.available", false);
         NO_LOCAL = config.property("no.local", true);
         SESSION_EXPIRY_GRACE_PERIOD = config.property("session.expiry.grace.period", 30);
+        CLIENT_ID = config.property("client.id", (String) null);
         MQTT_CONFIG = config;
     }
 
@@ -110,5 +112,10 @@ public class MqttConfiguration extends Configuration
     public int sessionExpiryGracePeriod()
     {
         return SESSION_EXPIRY_GRACE_PERIOD.get(this);
+    }
+
+    public String clientId()
+    {
+        return CLIENT_ID.get(this);
     }
 }

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -183,6 +183,8 @@ public final class MqttServerFactory implements StreamFactory
     private static final int CONNECT_TOPIC_ALIAS_MAXIMUM_MASK = 0b0000_0001;
     private static final int CONNECT_SESSION_EXPIRY_INTERVAL_MASK = 0b0000_0010;
 
+    private static final int CONNACK_SESSION_PRESENT = 0b0000_0001;
+
     private static final int RETAIN_HANDLING_SEND = 0;
 
     private static final int RETAIN_FLAG = 1 << RETAIN.ordinal();
@@ -2211,7 +2213,7 @@ public final class MqttServerFactory implements StreamFactory
             int propertiesSize = 0;
 
             MqttPropertyFW mqttProperty;
-            if (sessionExpiryInterval > sessionExpiryIntervalLimit && sessionExpiryIntervalLimit > 0)
+            if (sessionExpiryInterval > sessionExpiryIntervalLimit)
             {
                 mqttProperty = mqttPropertyRW.wrap(propertyBuffer, propertiesSize, propertyBuffer.capacity())
                                          .sessionExpiry(sessionExpiryIntervalLimit)
@@ -2275,7 +2277,7 @@ public final class MqttServerFactory implements StreamFactory
                 propertiesSize = mqttProperty.limit();
             }
 
-            int flags = 0x01;
+            int flags = 0x00;
 
             final int propertiesSize0 = propertiesSize;
             final MqttConnackFW connack =

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -68,6 +68,7 @@ import static org.reaktivity.nukleus.mqtt.internal.types.stream.MqttDataExFW.Bui
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -402,9 +403,8 @@ public final class MqttServerFactory implements StreamFactory
         this.encodeBudgetMax = bufferPool.slotCapacity();
         this.validator = new MqttValidator();
 
-        final String clientId = config.clientId();
-        this.supplyClientId = clientId != null ? () -> new String16FW(clientId) :
-            () -> new String16FW(UUID.randomUUID().toString());
+        final Optional<String16FW> clientId = Optional.ofNullable(config.clientId()).map(String16FW::new);
+        this.supplyClientId = clientId.isPresent() ? clientId::get : () -> new String16FW(UUID.randomUUID().toString());
     }
 
     @Override

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -2211,7 +2211,7 @@ public final class MqttServerFactory implements StreamFactory
             int propertiesSize = 0;
 
             MqttPropertyFW mqttProperty;
-            if (sessionExpiryIntervalLimit > 0)
+            if (sessionExpiryInterval > sessionExpiryIntervalLimit && sessionExpiryIntervalLimit > 0)
             {
                 mqttProperty = mqttPropertyRW.wrap(propertyBuffer, propertiesSize, propertyBuffer.capacity())
                                          .sessionExpiry(sessionExpiryIntervalLimit)

--- a/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
+++ b/src/main/java/org/reaktivity/nukleus/mqtt/internal/stream/MqttServerFactory.java
@@ -75,6 +75,7 @@ import java.util.function.Consumer;
 import java.util.function.LongFunction;
 import java.util.function.LongSupplier;
 import java.util.function.LongUnaryOperator;
+import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import javax.json.Json;
@@ -311,6 +312,7 @@ public final class MqttServerFactory implements StreamFactory
     private final byte sharedSubscriptions;
     private final boolean noLocal;
     private final int sessionExpiryGracePeriod;
+    private final Supplier<String16FW> supplyClientId;
 
     private final MqttValidator validator;
 
@@ -399,6 +401,10 @@ public final class MqttServerFactory implements StreamFactory
         this.sessionExpiryGracePeriod = config.sessionExpiryGracePeriod();
         this.encodeBudgetMax = bufferPool.slotCapacity();
         this.validator = new MqttValidator();
+
+        final String clientId = config.clientId();
+        this.supplyClientId = clientId != null ? () -> new String16FW(clientId) :
+            () -> new String16FW(UUID.randomUUID().toString());
     }
 
     @Override
@@ -1477,7 +1483,7 @@ public final class MqttServerFactory implements StreamFactory
 
                 if (length == 0)
                 {
-                    this.clientId = new String16FW(UUID.randomUUID().toString());
+                    this.clientId = supplyClientId.get();
                     this.assignedClientId = true;
                 }
                 else if (length > MAXIMUM_CLIENT_ID_LENGTH)

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -1145,19 +1145,4 @@ public class ConnectionIT
     {
         k3po.finish();
     }
-
-    @Test
-    @Specification({
-        "${routeExt}/session.present/server/controller",
-        "${client}/connect.when.session.present/client",
-        "${server}/connect.when.session.present/server"})
-    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
-    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
-    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
-    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "10")
-    @Configure(name = CLIENT_ID_NAME, value = "123e4567-e89b-42d3-a456-556642440000")
-    public void shouldConnectWhenSessionPresent() throws Exception
-    {
-        k3po.finish();
-    }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -18,7 +18,6 @@ package org.reaktivity.nukleus.mqtt.internal;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.PUBLISH_TIMEOUT;
-import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.CLIENT_ID_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.MAXIMUM_QOS_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.NO_LOCAL_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.RETAIN_AVAILABLE_NAME;

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -1144,4 +1144,18 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${routeExt}/session/server/controller",
+        "${client}/connect.with.session.expiry/client",
+        "${server}/connect.with.session.expiry/server"})
+    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
+    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "10")
+    public void shouldConnectWithSessionExpiry() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -1145,4 +1145,19 @@ public class ConnectionIT
     {
         k3po.finish();
     }
+
+    @Test
+    @Specification({
+        "${routeExt}/session.present/server/controller",
+        "${client}/connect.when.session.present/client",
+        "${server}/connect.when.session.present/server"})
+    @Configure(name = WILDCARD_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = SHARED_SUBSCRIPTION_AVAILABLE_NAME, value = "true")
+    @Configure(name = MAXIMUM_QOS_NAME, value = "2")
+    @Configure(name = SESSION_EXPIRY_INTERVAL_NAME, value = "10")
+    @Configure(name = CLIENT_ID_NAME, value = "123e4567-e89b-42d3-a456-556642440000")
+    public void shouldConnectWhenSessionPresent() throws Exception
+    {
+        k3po.finish();
+    }
 }

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/ConnectionIT.java
@@ -18,6 +18,7 @@ package org.reaktivity.nukleus.mqtt.internal;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.PUBLISH_TIMEOUT;
+import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.CLIENT_ID_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.MAXIMUM_QOS_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.NO_LOCAL_NAME;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfigurationTest.RETAIN_AVAILABLE_NAME;

--- a/src/test/java/org/reaktivity/nukleus/mqtt/internal/MqttConfigurationTest.java
+++ b/src/test/java/org/reaktivity/nukleus/mqtt/internal/MqttConfigurationTest.java
@@ -16,6 +16,7 @@
 package org.reaktivity.nukleus.mqtt.internal;
 
 import static org.junit.Assert.assertEquals;
+import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CLIENT_ID;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.CONNECT_TIMEOUT;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.MAXIMUM_QOS;
 import static org.reaktivity.nukleus.mqtt.internal.MqttConfiguration.NO_LOCAL;
@@ -43,6 +44,7 @@ public class MqttConfigurationTest
     static final String SHARED_SUBSCRIPTION_AVAILABLE_NAME = "nukleus.mqtt.shared.subscription.available";
     static final String NO_LOCAL_NAME = "nukleus.mqtt.no.local";
     static final String SESSION_EXPIRY_GRACE_PERIOD_NAME = "nukleus.mqtt.session.expiry.grace.period";
+    static final String CLIENT_ID_NAME = "nukleus.mqtt.client.id";
 
     @Test
     public void shouldVerifyConstants() throws Exception
@@ -58,5 +60,6 @@ public class MqttConfigurationTest
         assertEquals(SHARED_SUBSCRIPTION_AVAILABLE.name(), SHARED_SUBSCRIPTION_AVAILABLE_NAME);
         assertEquals(NO_LOCAL.name(), NO_LOCAL_NAME);
         assertEquals(SESSION_EXPIRY_GRACE_PERIOD.name(), SESSION_EXPIRY_GRACE_PERIOD_NAME);
+        assertEquals(CLIENT_ID.name(), CLIENT_ID_NAME);
     }
 }


### PR DESCRIPTION
Fix possible null pointer exceptions during will message encoding.

Fix sessionExpiryInterval property inappropriately being encoded in `CONNACK` under certain circumstances.

spec: https://github.com/reaktivity/nukleus-mqtt.spec/pull/56